### PR TITLE
Add Files to File Group doesn't bring up FileChooser

### DIFF
--- a/lib/BWidget/choosefile.tcl
+++ b/lib/BWidget/choosefile.tcl
@@ -121,7 +121,10 @@ proc ChooseFile::create { path args } {
         set shell [$popdown $data(FolderCombo)]
         set listbox $shell.l
         destroy $listbox
-        grid remove $shell.sb
+        # Uncommenting this line causes the grid remove call to hang
+        # and therefore not return. The user never sees the file chooser
+        # dialog. This happens on Debian Squeeze 64 bit
+        ## grid remove $shell.sb
 
         bind $shell <Unmap> [list after idle [list focus $frame.listbox]]
 


### PR DESCRIPTION
## Platform

Debian Squeeze 64 bit... 
Linux <machine> 2.6.32-5-amd64 #1 SMP Mon Mar 7 21:35:22 UTC 2011 x86_64 GNU/Linux
## Issue

When a user wants to add files into a file group (in the Components and Files -> Groups and Files menu -> [ right click menu -> Add Files || icon menu -> button with tooltip= "Add Files to File Group"] the file chooser window is never displayed. I inserted log statements around the code that is called from this action, and found that in the ChooseFile::create proc, the line:
`grid remove $shell.sb`
never returns (or does something funky that doesn't allow the rest of the statements in the create function to execute.
